### PR TITLE
Improve client networking and UI helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
 # ArtAgent-android
-An Art Agent based on GPT4, Stable Diffusion, and finetuned VisualGLM-6B
-# ArtAgent User Manual
-https://open-spur-1bb.notion.site/ArtAgent-791e0a7408f2423e9605aee195905dd5
+
+ArtAgent-android is an Android client for the ArtAgent system. It combines GPT-4, Stable Diffusion and a finetuned VisualGLM-6B model to provide intelligent conversation and image generation on mobile devices.
+
+## Features
+- Chat with AI characters powered by GPT-4/VisualGLM-6B
+- Generate images through Stable Diffusion
+- Floating window service for convenient access
+- Custom drawing canvas with single and double click support
+
+## Requirements
+- Android Studio or Gradle
+- JDK 8+
+- Android device or emulator running Android 8.0+
+
+## Build
+```bash
+chmod +x gradlew
+./gradlew assembleDebug
+```
+
+## Usage
+The project documentation and user manual are available [here](https://open-spur-1bb.notion.site/ArtAgent-791e0a7408f2423e9605aee195905dd5). After building, install the generated APK on your device to explore the ArtAgent features.
+
+## License
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/app/src/main/java/com/fxz/artagent/AppClient.java
+++ b/app/src/main/java/com/fxz/artagent/AppClient.java
@@ -47,36 +47,40 @@ public class AppClient {
 
     public String doRequest(JSONObject requestData, Map<String, String> requestPathMap) throws IOException, SignatureException {
         URL realUrl = new URL(buildAuthRequestUrl());
-        URLConnection connection = realUrl.openConnection();
-        HttpURLConnection httpURLConnection = (HttpURLConnection) connection;
+        HttpURLConnection httpURLConnection = (HttpURLConnection) realUrl.openConnection();
         httpURLConnection.setDoInput(true);
         httpURLConnection.setDoOutput(true);
         httpURLConnection.setRequestMethod("POST");
-        httpURLConnection.setRequestProperty("Content-type","application/json");
+        httpURLConnection.setRequestProperty("Content-type", "application/json");
 
-        OutputStream out = httpURLConnection.getOutputStream();
         String newRequestData = this.buildRequestData(requestData, requestPathMap);
-        out.write(newRequestData.getBytes());
-        out.flush();
+        try (OutputStream out = httpURLConnection.getOutputStream()) {
+            out.write(newRequestData.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        }
 
         logger.info("send data is :{}", newRequestData);
 
-        InputStream is;
-        try{
-            is = httpURLConnection.getInputStream();
-        }catch (Exception e){
-            is = httpURLConnection.getErrorStream();
-            logger.error("request message is {}, code is:{}", httpURLConnection.getResponseMessage(), readAllBytes(is));
+        String respData;
+        try (InputStream is = httpURLConnection.getInputStream()) {
+            respData = readAllBytes(is);
+        } catch (IOException e) {
+            try (InputStream es = httpURLConnection.getErrorStream()) {
+                String error = es != null ? readAllBytes(es) : e.getMessage();
+                logger.error("request message is {}, code is:{}", httpURLConnection.getResponseMessage(), error);
+                respData = error;
+            }
+        } finally {
+            httpURLConnection.disconnect();
         }
 
-        String respData = readAllBytes(is);
         logger.info("respData:{}", respData);
 
         JSONObject jsonObject = JSONObject.parseObject(respData);
         JSONObject payload = jsonObject.getJSONObject("payload");
         JSONObject output_text = payload.getJSONObject("output_text");
         String text = output_text.getString("text");
-        String textBase64Decode=new String(Base64.getDecoder().decode(text), StandardCharsets.UTF_8);
+        String textBase64Decode = new String(Base64.getDecoder().decode(text), StandardCharsets.UTF_8);
         System.out.println("\ntext字段解析结果：");
         System.out.println(textBase64Decode);
 

--- a/app/src/main/java/com/fxz/artagent/DoubleClickListener.java
+++ b/app/src/main/java/com/fxz/artagent/DoubleClickListener.java
@@ -1,44 +1,48 @@
 package com.fxz.artagent;
 
 import android.os.Handler;
+import android.os.Looper;
 import android.view.MotionEvent;
 import android.view.View;
 
 public class DoubleClickListener implements View.OnTouchListener {
     private static final long DOUBLE_CLICK_TIME_DELTA = 300; // 设置双击的时间间隔，单位毫秒
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private final Runnable singleClickRunnable = () -> {
+        if (waitingForSecondClick && currentView != null) {
+            waitingForSecondClick = false;
+            onSingleClick(currentView);
+            currentView = null;
+        }
+    };
     private long lastClickTime = 0;
     private boolean waitingForSecondClick = false;
-    private Handler handler = new Handler();
+    private View currentView;
 
     @Override
     public boolean onTouch(View v, MotionEvent event) {
         if (event.getAction() == MotionEvent.ACTION_DOWN) {
             long clickTime = System.currentTimeMillis();
             if (clickTime - lastClickTime < DOUBLE_CLICK_TIME_DELTA) {
-                // 双击事件
-                handler.removeCallbacksAndMessages(null);
+                handler.removeCallbacks(singleClickRunnable);
                 waitingForSecondClick = false;
+                currentView = null;
                 onDoubleClick(v);
             } else {
-                // 单击事件
                 waitingForSecondClick = true;
-                handler.postDelayed(() -> {
-                    if (waitingForSecondClick) {
-                        waitingForSecondClick = false;
-                        onSingleClick(v);
-                    }
-                }, DOUBLE_CLICK_TIME_DELTA);
+                currentView = v;
+                handler.postDelayed(singleClickRunnable, DOUBLE_CLICK_TIME_DELTA);
             }
             lastClickTime = clickTime;
         }
         return true;
     }
 
-    public void onSingleClick(View v) {
+    protected void onSingleClick(View v) {
         // 处理单击事件
     }
 
-    public void onDoubleClick(View v) {
+    protected void onDoubleClick(View v) {
         // 处理双击事件
     }
 }

--- a/app/src/main/java/com/fxz/artagent/DrawingView.java
+++ b/app/src/main/java/com/fxz/artagent/DrawingView.java
@@ -6,13 +6,10 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
-import android.provider.MediaStore;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
-import android.widget.Toast;
 
-import java.util.UUID;
 
 public class DrawingView extends View {
 
@@ -27,8 +24,11 @@ public class DrawingView extends View {
     }
 
     public void clearCanvas() {  // 清除画板
-        drawCanvas.drawColor(Color.WHITE);
-        invalidate();
+        if (drawCanvas != null) {
+            drawCanvas.drawColor(Color.WHITE);
+            drawPath.reset();
+            invalidate();
+        }
     }
 
     public void setBrushSize(float newSize) {  // 不同画笔大小


### PR DESCRIPTION
## Summary
- ensure `AppClient` closes streams and disconnects HTTP connections
- reuse handler runnable for more robust double-click detection
- guard `DrawingView` when clearing the canvas and drop unused imports
- expand README with features, build instructions and usage info

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_688ae02da860832ebc9c613f18fa7452